### PR TITLE
pr Feat/백과사전 데이터 기능 api구현

### DIFF
--- a/src/main/java/capstone/demo/domain/adapter/Adapter.java
+++ b/src/main/java/capstone/demo/domain/adapter/Adapter.java
@@ -1,0 +1,34 @@
+package capstone.demo.domain.adapter;
+
+import capstone.demo.domain.user.entity.User;
+import capstone.demo.domain.voice.entity.VoiceModel;
+import capstone.demo.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Adapter extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "adapter_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", unique = true)
+    private User user;
+
+    @Column(name = "voice_model")
+    private VoiceModel voiceModel;
+
+    @Column(name = "adapter_number")
+    private Long adapterNumber;
+
+
+}

--- a/src/main/java/capstone/demo/domain/adapter/AdapterRepository.java
+++ b/src/main/java/capstone/demo/domain/adapter/AdapterRepository.java
@@ -1,0 +1,11 @@
+package capstone.demo.domain.adapter;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface AdapterRepository extends JpaRepository<Adapter, Integer> {
+
+    Optional<Adapter> findByUserId(Long id);
+}

--- a/src/main/java/capstone/demo/domain/adapter/AdapterService.java
+++ b/src/main/java/capstone/demo/domain/adapter/AdapterService.java
@@ -1,0 +1,25 @@
+package capstone.demo.domain.adapter;
+
+import capstone.demo.domain.user.entity.User;
+import capstone.demo.domain.voice.entity.VoiceModel;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdapterService {
+
+    private final AdapterRepository adapterRepository;
+
+    public void saveUsersAdapterId(User user, Long adapterNumber, VoiceModel voiceModel) {
+        adapterRepository.save(Adapter.builder()
+                        .user(user)
+                        .adapterNumber(adapterNumber)
+                        .voiceModel(voiceModel)
+                        .build());
+    }
+
+    public Adapter findByUser(User user) {
+        return adapterRepository.findByUserId(user.getId()).orElse(null);
+    }
+}

--- a/src/main/java/capstone/demo/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/capstone/demo/domain/bookmark/controller/BookmarkController.java
@@ -1,7 +1,5 @@
 package capstone.demo.domain.bookmark.controller;
 
-import capstone.demo.domain.bookmark.Bookmark;
-import capstone.demo.domain.bookmark.dto.BookmarkResponse;
 import capstone.demo.domain.bookmark.service.BookmarkService;
 import capstone.demo.domain.dictionary.Dictionary;
 import capstone.demo.global.apiPayload.ApiResponse;
@@ -19,17 +17,6 @@ import java.util.List;
 public class BookmarkController {
 
     private final BookmarkService bookmarkService;
-
-    @PutMapping("/bookmark")
-    @Operation(summary = "북마크 토글", description = "북마크 상태를 토글합니다.")
-    public ResponseEntity<ApiResponse<BookmarkResponse>> toggleBookmark(
-            @AuthenticationPrincipal AuthDetails authDetails,
-            @RequestParam Long dictionaryId
-    ) {
-        BookmarkResponse resp = bookmarkService.toggleBookmark(authDetails.user(), dictionaryId);
-        return ResponseEntity.ok(ApiResponse.onSuccess(resp));
-    }
-
 
     @GetMapping("/bookmark/list")
     @Operation(summary = "북마크 리스트 조회하기",

--- a/src/main/java/capstone/demo/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/capstone/demo/domain/bookmark/controller/BookmarkController.java
@@ -10,10 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -23,16 +20,16 @@ public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
-    @PostMapping("/bookmark")
-    @Operation(summary = "북마크 저장하기",
-            description = "백과사전에서 원하는 항목을 북마크하는 API입니다.")
-    public ResponseEntity<ApiResponse<BookmarkResponse>> addBookmark(
+    @PutMapping("/bookmark")
+    @Operation(summary = "북마크 토글", description = "북마크 상태를 토글합니다.")
+    public ResponseEntity<ApiResponse<BookmarkResponse>> toggleBookmark(
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestParam Long dictionaryId
     ) {
-        BookmarkResponse resp = bookmarkService.addBookmark(authDetails.user() , dictionaryId);
+        BookmarkResponse resp = bookmarkService.toggleBookmark(authDetails.user(), dictionaryId);
         return ResponseEntity.ok(ApiResponse.onSuccess(resp));
     }
+
 
     @GetMapping("/bookmark/list")
     @Operation(summary = "북마크 리스트 조회하기",

--- a/src/main/java/capstone/demo/domain/bookmark/dto/BookmarkResponse.java
+++ b/src/main/java/capstone/demo/domain/bookmark/dto/BookmarkResponse.java
@@ -10,6 +10,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class BookmarkResponse {
-    private Long bookMarkId;
-    private String message;
+    private Long dictionaryId;
+    private boolean bookmarked;
+
+    public static BookmarkResponse of(Long id, boolean bookmarked) {
+        return BookmarkResponse.builder()
+                .dictionaryId(id)
+                .bookmarked(bookmarked)
+                .build();
+    }
 }

--- a/src/main/java/capstone/demo/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/capstone/demo/domain/bookmark/repository/BookmarkRepository.java
@@ -2,11 +2,13 @@ package capstone.demo.domain.bookmark.repository;
 
 import capstone.demo.domain.bookmark.Bookmark;
 import capstone.demo.domain.dictionary.Dictionary;
+import capstone.demo.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
@@ -34,4 +36,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     """,
             nativeQuery = true)
     List<Dictionary> getNextPage(Long userId, Long lastId, int size);
+
+    Optional<Bookmark> findAllByUser(User user);
+
+    Optional<Bookmark> findByUserAndDictionaryId(User user, Long dictionaryId);
 }

--- a/src/main/java/capstone/demo/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/capstone/demo/domain/bookmark/service/BookmarkService.java
@@ -10,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -17,17 +20,27 @@ public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
     private final DictionaryService dictionaryService;
 
-    public BookmarkResponse addBookmark(User user, Long dictionaryId) {
+    public BookmarkResponse toggleBookmark(User user, Long dictionaryId) {
+
+        Optional<Bookmark> existing =
+                bookmarkRepository.findByUserAndDictionaryId(user, dictionaryId);
+
+        // 이미 있으면 삭제 → "북마크 해제됨" 반환
+        if (existing.isPresent()) {
+            bookmarkRepository.delete(existing.get());
+            return BookmarkResponse.of(dictionaryId, false);
+        }
+
         Dictionary dictionary = dictionaryService.getById(dictionaryId);
-        Bookmark bookmark = Bookmark.builder().dictionary(dictionary).user(user).build();
+
+        Bookmark bookmark = Bookmark.builder()
+                .user(user)
+                .dictionary(dictionary)
+                .build();
 
         bookmarkRepository.save(bookmark);
 
-        return BookmarkResponse.builder()
-                .bookMarkId(dictionary.getId())
-                .message("북마크 저장 성공")
-                .build();
-
+        return BookmarkResponse.of(dictionaryId, true); // bookmarked = true
     }
 
     public List<Dictionary> getFirstPage(User user, int size) {
@@ -37,5 +50,11 @@ public class BookmarkService {
     public List<Dictionary> getNextPage(User user, Long lastId, int size) {
         return bookmarkRepository.getNextPage(user.getId(), lastId, size);
 
+    }
+
+    public Set<Long> getBookmarkDictionaryIds(User user) {
+        return bookmarkRepository.findAllByUser(user).stream()
+                .map(b -> b.getDictionary().getId())
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/capstone/demo/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/capstone/demo/domain/bookmark/service/BookmarkService.java
@@ -1,10 +1,8 @@
 package capstone.demo.domain.bookmark.service;
 
 import capstone.demo.domain.bookmark.Bookmark;
-import capstone.demo.domain.bookmark.dto.BookmarkResponse;
 import capstone.demo.domain.bookmark.repository.BookmarkRepository;
 import capstone.demo.domain.dictionary.Dictionary;
-import capstone.demo.domain.dictionary.service.DictionaryService;
 import capstone.demo.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,30 +16,6 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class BookmarkService {
     private final BookmarkRepository bookmarkRepository;
-    private final DictionaryService dictionaryService;
-
-    public BookmarkResponse toggleBookmark(User user, Long dictionaryId) {
-
-        Optional<Bookmark> existing =
-                bookmarkRepository.findByUserAndDictionaryId(user, dictionaryId);
-
-        // 이미 있으면 삭제 → "북마크 해제됨" 반환
-        if (existing.isPresent()) {
-            bookmarkRepository.delete(existing.get());
-            return BookmarkResponse.of(dictionaryId, false);
-        }
-
-        Dictionary dictionary = dictionaryService.getById(dictionaryId);
-
-        Bookmark bookmark = Bookmark.builder()
-                .user(user)
-                .dictionary(dictionary)
-                .build();
-
-        bookmarkRepository.save(bookmark);
-
-        return BookmarkResponse.of(dictionaryId, true); // bookmarked = true
-    }
 
     public List<Dictionary> getFirstPage(User user, int size) {
         return bookmarkRepository.getFirstPage(user.getId(), size);
@@ -56,5 +30,17 @@ public class BookmarkService {
         return bookmarkRepository.findAllByUser(user).stream()
                 .map(b -> b.getDictionary().getId())
                 .collect(Collectors.toSet());
+    }
+
+    public Optional<Bookmark> findByUserAndDictionaryId(User user, Long dictionaryId) {
+        return bookmarkRepository.findByUserAndDictionaryId(user, dictionaryId);
+    }
+
+    public void delete(Bookmark bookmark) {
+        bookmarkRepository.delete(bookmark);
+    }
+
+    public void save(Bookmark bookmark) {
+        bookmarkRepository.save(bookmark);
     }
 }

--- a/src/main/java/capstone/demo/domain/dictionary/Dictionary.java
+++ b/src/main/java/capstone/demo/domain/dictionary/Dictionary.java
@@ -2,14 +2,12 @@ package capstone.demo.domain.dictionary;
 
 import capstone.demo.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
 @Builder
+@Setter
 @AllArgsConstructor
 @NoArgsConstructor
 public class Dictionary extends BaseEntity {

--- a/src/main/java/capstone/demo/domain/dictionary/Dictionary.java
+++ b/src/main/java/capstone/demo/domain/dictionary/Dictionary.java
@@ -21,8 +21,8 @@ public class Dictionary extends BaseEntity {
     @Column(length = 50, name = "gesture_name")
     private String gestureName;
 
-    @Column(length = 512, name = "gesture_url")
-    private String gestureUrl;
+    @Column(length = 512, name = "object_key")
+    private String objectKey;
 
 
 }

--- a/src/main/java/capstone/demo/domain/dictionary/controller/DictionaryController.java
+++ b/src/main/java/capstone/demo/domain/dictionary/controller/DictionaryController.java
@@ -1,5 +1,6 @@
 package capstone.demo.domain.dictionary.controller;
 
+import capstone.demo.domain.dictionary.dto.DictionaryBookmarkResponse;
 import capstone.demo.domain.dictionary.Dictionary;
 import capstone.demo.domain.dictionary.dto.DictionaryResponse;
 import capstone.demo.domain.dictionary.service.DictionaryService;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,6 +22,16 @@ import java.util.List;
 public class DictionaryController {
 
     private final DictionaryService dictionaryService;
+
+    @PutMapping("/dictionary/bookmark")
+    @Operation(summary = "북마크 토글", description = "북마크 상태를 토글합니다.")
+    public ResponseEntity<ApiResponse<DictionaryBookmarkResponse>> toggleBookmark(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestParam Long dictionaryId
+    ) {
+        DictionaryBookmarkResponse resp = dictionaryService.toggleBookmark(authDetails.user(), dictionaryId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(resp));
+    }
 
     @GetMapping("/dictionary/list")
     @Operation(summary = "수화 사전 무한 스크롤 리스트 조회",

--- a/src/main/java/capstone/demo/domain/dictionary/controller/DictionaryController.java
+++ b/src/main/java/capstone/demo/domain/dictionary/controller/DictionaryController.java
@@ -4,9 +4,11 @@ import capstone.demo.domain.dictionary.Dictionary;
 import capstone.demo.domain.dictionary.dto.DictionaryResponse;
 import capstone.demo.domain.dictionary.service.DictionaryService;
 import capstone.demo.global.apiPayload.ApiResponse;
+import capstone.demo.global.security.AuthDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -23,16 +25,17 @@ public class DictionaryController {
     @GetMapping("/dictionary/list")
     @Operation(summary = "수화 사전 무한 스크롤 리스트 조회",
             description = "lastId 기반으로 무한 스크롤 형식으로 조회합니다.")
-    public ResponseEntity<ApiResponse<List<Dictionary>>> getDictionaryList(
+    public ResponseEntity<ApiResponse<List<DictionaryResponse>>> getDictionaryList(
+            @AuthenticationPrincipal AuthDetails authDetails,
             @RequestParam(required = false) Long lastId,
             @RequestParam(defaultValue = "20") int size
     ) {
-        List<Dictionary> result;
+        List<DictionaryResponse> result;
 
         if (lastId == null) {
-            result = dictionaryService.getFirstPage(size);
+            result = dictionaryService.getFirstPage(authDetails.user(), size);
         } else {
-            result = dictionaryService.getNextPage(lastId, size);
+            result = dictionaryService.getNextPage(authDetails.user(), lastId, size);
         }
 
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
@@ -51,7 +54,7 @@ public class DictionaryController {
     }
 
 //    @PostMapping("/sync-s3")
-//    public String syncObjectKeys(@RequestParam String bucketName) {
+//    public String syncObjectKeys(@RequestPara m String bucketName) {
 //        dictionaryService.updateObjectKeysFromS3(bucketName);
 //        return "OK - S3 keys synced to dictionary DB";
 //    }

--- a/src/main/java/capstone/demo/domain/dictionary/controller/DictionaryController.java
+++ b/src/main/java/capstone/demo/domain/dictionary/controller/DictionaryController.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/capstone/demo/domain/dictionary/controller/DictionaryController.java
+++ b/src/main/java/capstone/demo/domain/dictionary/controller/DictionaryController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -49,4 +50,9 @@ public class DictionaryController {
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
+//    @PostMapping("/sync-s3")
+//    public String syncObjectKeys(@RequestParam String bucketName) {
+//        dictionaryService.updateObjectKeysFromS3(bucketName);
+//        return "OK - S3 keys synced to dictionary DB";
+//    }
 }

--- a/src/main/java/capstone/demo/domain/dictionary/dto/DictionaryBookmarkResponse.java
+++ b/src/main/java/capstone/demo/domain/dictionary/dto/DictionaryBookmarkResponse.java
@@ -1,4 +1,4 @@
-package capstone.demo.domain.bookmark.dto;
+package capstone.demo.domain.dictionary.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -9,12 +9,12 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class BookmarkResponse {
+public class DictionaryBookmarkResponse {
     private Long dictionaryId;
     private boolean bookmarked;
 
-    public static BookmarkResponse of(Long id, boolean bookmarked) {
-        return BookmarkResponse.builder()
+    public static DictionaryBookmarkResponse of(Long id, boolean bookmarked) {
+        return DictionaryBookmarkResponse.builder()
                 .dictionaryId(id)
                 .bookmarked(bookmarked)
                 .build();

--- a/src/main/java/capstone/demo/domain/dictionary/dto/DictionaryResponse.java
+++ b/src/main/java/capstone/demo/domain/dictionary/dto/DictionaryResponse.java
@@ -10,5 +10,6 @@ import lombok.*;
 public class DictionaryResponse {
     private Long id;
     private String gestureName;
-    private String gestureUrl;
+    private String objectKey;
+    private boolean isbookmarked;
 }

--- a/src/main/java/capstone/demo/domain/dictionary/repository/DictionaryRepository.java
+++ b/src/main/java/capstone/demo/domain/dictionary/repository/DictionaryRepository.java
@@ -33,4 +33,6 @@ public interface DictionaryRepository extends JpaRepository<Dictionary, Long> {
             "ORDER BY dictionary_id DESC",
             nativeQuery = true)
     List<Dictionary> findAllByKeyword(String keyword);
+
+    List<Dictionary> findAllByGestureNameIn(List<String> gestureNames);
 }

--- a/src/main/java/capstone/demo/domain/dictionary/service/DictionaryService.java
+++ b/src/main/java/capstone/demo/domain/dictionary/service/DictionaryService.java
@@ -1,21 +1,20 @@
 package capstone.demo.domain.dictionary.service;
 
+import capstone.demo.domain.bookmark.Bookmark;
+import capstone.demo.domain.dictionary.dto.DictionaryBookmarkResponse;
 import capstone.demo.domain.bookmark.service.BookmarkService;
 import capstone.demo.domain.dictionary.Dictionary;
 import capstone.demo.domain.dictionary.dto.DictionaryResponse;
 import capstone.demo.domain.dictionary.repository.DictionaryRepository;
-import capstone.demo.domain.fileload.S3FileService;
 import capstone.demo.domain.user.entity.User;
 import capstone.demo.global.apiPayload.code.status.ErrorStatus;
 import capstone.demo.global.apiPayload.exception.handler.NotFoundHandler;
-import com.amazonaws.services.kms.model.NotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -67,6 +66,29 @@ public class DictionaryService {
 
     public List<Dictionary> findAllByGestureNameIn(List<String> contents) {
         return dictionaryRepository.findAllByGestureNameIn(contents);
+    }
+
+    public DictionaryBookmarkResponse toggleBookmark(User user, Long dictionaryId) {
+
+        Optional<Bookmark> existing =
+                bookmarkService.findByUserAndDictionaryId(user, dictionaryId);
+
+        // 이미 있으면 삭제 → "북마크 해제됨" 반환
+        if (existing.isPresent()) {
+            bookmarkService.delete(existing.get());
+            return DictionaryBookmarkResponse.of(dictionaryId, false);
+        }
+
+        Dictionary dictionary = getById(dictionaryId);
+
+        Bookmark bookmark = Bookmark.builder()
+                .user(user)
+                .dictionary(dictionary)
+                .build();
+
+        bookmarkService.save(bookmark);
+
+        return DictionaryBookmarkResponse.of(dictionaryId, true); // bookmarked = true
     }
 
 

--- a/src/main/java/capstone/demo/domain/dictionary/service/DictionaryService.java
+++ b/src/main/java/capstone/demo/domain/dictionary/service/DictionaryService.java
@@ -2,10 +2,12 @@ package capstone.demo.domain.dictionary.service;
 
 import capstone.demo.domain.dictionary.Dictionary;
 import capstone.demo.domain.dictionary.repository.DictionaryRepository;
+import capstone.demo.domain.fileload.S3FileService;
 import capstone.demo.global.apiPayload.code.status.ErrorStatus;
 import capstone.demo.global.apiPayload.exception.handler.NotFoundHandler;
 import com.amazonaws.services.kms.model.NotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -13,6 +15,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class DictionaryService {
+    private final S3FileService s3FileService;
     private final DictionaryRepository dictionaryRepository;
 
     public List<Dictionary> getFirstPage(int size) {
@@ -30,4 +33,30 @@ public class DictionaryService {
     public List<Dictionary> searchAll(String keyword) {
         return dictionaryRepository.findAllByKeyword(keyword);
     }
+
+//    public void updateObjectKeysFromS3(String bucketName) {
+//
+//        // 1. S3에서 videos/ 아래 key 전체 조회 (정렬된 상태)
+//        List<String> s3Keys = s3FileService.listObjectKeys("videos/", bucketName);
+//
+//        // S3는 prefix 폴더 자체("videos/")의 빈 엔트리를 포함할 수 있으므로 제거
+//        s3Keys = s3Keys.stream()
+//                .filter(key -> !key.equals("videos/"))
+//                .sorted()
+//                .toList();
+//
+//        // 2. DB에서 gesture_name 정렬 순으로 dictionary 조회
+//        List<Dictionary> dictionaries = dictionaryRepository.findAll(Sort.by("id"));
+//
+//        if (dictionaries.size() != s3Keys.size()) {
+//            throw new IllegalStateException("DB row count and S3 object count do not match!");
+//        }
+//
+//        for (int i = 0; i < dictionaries.size(); i++) {
+//            Dictionary dict = dictionaries.get(i);
+//            dict.setObjectKey(s3Keys.get(i));  // 엔티티에 setter 필요
+//        }
+//
+//        dictionaryRepository.saveAll(dictionaries);
+//    }
 }

--- a/src/main/java/capstone/demo/domain/dictionary/service/DictionaryService.java
+++ b/src/main/java/capstone/demo/domain/dictionary/service/DictionaryService.java
@@ -65,6 +65,10 @@ public class DictionaryService {
         return dictionaryRepository.findAllByKeyword(keyword);
     }
 
+    public List<Dictionary> findAllByGestureNameIn(List<String> contents) {
+        return dictionaryRepository.findAllByGestureNameIn(contents);
+    }
+
 
 //    public void updateObjectKeysFromS3(String bucketName) {
 //

--- a/src/main/java/capstone/demo/domain/dictionary/service/DictionaryService.java
+++ b/src/main/java/capstone/demo/domain/dictionary/service/DictionaryService.java
@@ -1,8 +1,11 @@
 package capstone.demo.domain.dictionary.service;
 
+import capstone.demo.domain.bookmark.service.BookmarkService;
 import capstone.demo.domain.dictionary.Dictionary;
+import capstone.demo.domain.dictionary.dto.DictionaryResponse;
 import capstone.demo.domain.dictionary.repository.DictionaryRepository;
 import capstone.demo.domain.fileload.S3FileService;
+import capstone.demo.domain.user.entity.User;
 import capstone.demo.global.apiPayload.code.status.ErrorStatus;
 import capstone.demo.global.apiPayload.exception.handler.NotFoundHandler;
 import com.amazonaws.services.kms.model.NotFoundException;
@@ -11,19 +14,47 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class DictionaryService {
-    private final S3FileService s3FileService;
+//    private final S3FileService s3FileService;
     private final DictionaryRepository dictionaryRepository;
+    private final BookmarkService bookmarkService;
 
-    public List<Dictionary> getFirstPage(int size) {
-        return dictionaryRepository.getFirstPage(size);
+    public List<DictionaryResponse> getFirstPage(User user, int size) {
+        Set<Long> bookmarkedIds = bookmarkService.getBookmarkDictionaryIds(user);
+
+        List<Dictionary> dictionaries = dictionaryRepository.getFirstPage(size);
+
+        return dictionaries.stream()
+                .map(d -> DictionaryResponse.builder()
+                        .id(d.getId())
+                        .gestureName(d.getGestureName())
+                        .objectKey(d.getObjectKey())
+                        .isbookmarked(bookmarkedIds.contains(d.getId()))
+                        .build())
+                .toList();
+
+
     }
 
-    public List<Dictionary> getNextPage(Long lastId, int size) {
-        return dictionaryRepository.getNextPage(lastId, size);
+    public List<DictionaryResponse> getNextPage(User user, Long lastId, int size) {
+        Set<Long> bookmarkedIds = bookmarkService.getBookmarkDictionaryIds(user);
+
+        List<Dictionary> dictionaries = dictionaryRepository.getNextPage(lastId, size);
+
+        return dictionaries.stream()
+                .map(d -> DictionaryResponse.builder()
+                        .id(d.getId())
+                        .gestureName(d.getGestureName())
+                        .objectKey(d.getObjectKey())
+                        .isbookmarked(bookmarkedIds.contains(d.getId()))
+                        .build())
+                .toList();
+
     }
 
     public Dictionary getById(Long id) {
@@ -33,6 +64,7 @@ public class DictionaryService {
     public List<Dictionary> searchAll(String keyword) {
         return dictionaryRepository.findAllByKeyword(keyword);
     }
+
 
 //    public void updateObjectKeysFromS3(String bucketName) {
 //

--- a/src/main/java/capstone/demo/domain/fileload/S3FileController.java
+++ b/src/main/java/capstone/demo/domain/fileload/S3FileController.java
@@ -24,7 +24,7 @@ public class S3FileController {
     @Value("${amazon.aws.bucket}")
     private String bucketName;
 
-    @GetMapping("/generate-presigned-url")
+    @GetMapping("/generate-put-presigned-url")
     @Operation(summary = "음성 업로드용 presigned url 발급", description = "음성 업로드용 presigned url을 발급합니다.")
     public ResponseEntity<ApiResponse<PreSignedUrlResponseDto>> generatePresignedUrl(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam String extension){
 

--- a/src/main/java/capstone/demo/domain/fileload/S3FileController.java
+++ b/src/main/java/capstone/demo/domain/fileload/S3FileController.java
@@ -36,4 +36,12 @@ public class S3FileController {
                 ApiResponse.onSuccess(s3FileService.generatePreSignPutUrl(userId, extension, bucketName)));
     }
 
+    @GetMapping("/generate-get-presigned-url")
+    @Operation(summary = "조회용 presigned url 발급", description = "조회용 presigned url을 발급합니다.")
+    public ResponseEntity<ApiResponse<PreSignedUrlResponseDto>> generateGetPresignedUrl(@AuthenticationPrincipal AuthDetails authDetails, @RequestParam String objectKey){
+
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(s3FileService.sendPreSignGetUrl(authDetails.user(), objectKey, bucketName)));
+    }
+
 }

--- a/src/main/java/capstone/demo/domain/fileload/S3FileController.java
+++ b/src/main/java/capstone/demo/domain/fileload/S3FileController.java
@@ -1,6 +1,7 @@
 package capstone.demo.domain.fileload;
 
 import capstone.demo.domain.fileload.dto.PreSignedUrlResponseDto;
+import capstone.demo.domain.voice.entity.VoiceModel;
 import capstone.demo.global.apiPayload.ApiResponse;
 import capstone.demo.global.security.AuthDetails;
 import capstone.demo.global.util.GlobalAuthUtil;
@@ -11,8 +12,12 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
 
 
 @RestController
@@ -43,5 +48,15 @@ public class S3FileController {
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(s3FileService.sendPreSignGetUrl(authDetails.user(), objectKey, bucketName)));
     }
+
+    @PostMapping("/presigned/put/multiple")
+    @Operation(summary = "AI 학습용 데이터 관련 presigned url 발급", description = "AI 학습용 데이터 관련 presigned url을 발급합니다.")
+    public List<PreSignedUrlResponseDto> createMultiplePresignedPutUrls(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestParam VoiceModel voiceModel
+            ) {
+        return s3FileService.generateMultiplePreSignPutUrls(authDetails.user(), bucketName, voiceModel);
+    }
+
 
 }

--- a/src/main/java/capstone/demo/domain/fileload/S3FileService.java
+++ b/src/main/java/capstone/demo/domain/fileload/S3FileService.java
@@ -6,12 +6,13 @@ import com.amazonaws.HttpMethod;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.Calendar;
-import java.util.Date;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 public class S3FileService {
@@ -72,4 +73,19 @@ public class S3FileService {
                 .expiresAt(Date.from(new Date().toInstant()))
                 .build();
     }
+
+//    public List<String> listObjectKeys(String prefix, String bucketName) {
+//        ListObjectsV2Request req = new ListObjectsV2Request()
+//                .withBucketName(bucketName)
+//                .withPrefix(prefix);
+//
+//        ListObjectsV2Result result = amazonS3.listObjectsV2(req);
+//
+//        List<String> keys = new ArrayList<>();
+//        for (S3ObjectSummary obj : result.getObjectSummaries()) {
+//            keys.add(obj.getKey());
+//        }
+//
+//        return keys;
+//    }
 }

--- a/src/main/java/capstone/demo/domain/fileload/S3FileService.java
+++ b/src/main/java/capstone/demo/domain/fileload/S3FileService.java
@@ -1,6 +1,7 @@
 package capstone.demo.domain.fileload;
 
 import capstone.demo.domain.fileload.dto.PreSignedUrlResponseDto;
+import capstone.demo.domain.user.entity.User;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
@@ -62,4 +63,13 @@ public class S3FileService {
     }
 
 
+    public PreSignedUrlResponseDto sendPreSignGetUrl(User user, String objectKey, String bucketName) {
+        String preSignedUrl = generatePreSignGetUrl(objectKey, bucketName);
+
+        return PreSignedUrlResponseDto.builder()
+                .preSignedUrl(preSignedUrl)
+                .objectKey(objectKey)
+                .expiresAt(Date.from(new Date().toInstant()))
+                .build();
+    }
 }

--- a/src/main/java/capstone/demo/domain/fileload/S3FileService.java
+++ b/src/main/java/capstone/demo/domain/fileload/S3FileService.java
@@ -2,6 +2,7 @@ package capstone.demo.domain.fileload;
 
 import capstone.demo.domain.fileload.dto.PreSignedUrlResponseDto;
 import capstone.demo.domain.user.entity.User;
+import capstone.demo.domain.voice.entity.VoiceModel;
 import com.amazonaws.HttpMethod;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
@@ -16,10 +17,9 @@ import java.util.*;
 
 @Service
 public class S3FileService {
-
+    static final int fileCount = 20;
     @Autowired
     private AmazonS3 amazonS3;
-
     public PreSignedUrlResponseDto generatePreSignPutUrl(Long userId,
                                                       String extension,
                                                       String bucketName){
@@ -73,6 +73,63 @@ public class S3FileService {
                 .expiresAt(Date.from(new Date().toInstant()))
                 .build();
     }
+
+    public List<PreSignedUrlResponseDto> generateMultiplePreSignPutUrls(
+            User user,
+            String bucketName,
+            VoiceModel voiceModel
+    ) {
+
+        List<PreSignedUrlResponseDto> result = new ArrayList<>();
+
+        for (int i = 0; i < fileCount; i++) {
+            String objectKey =  voiceModel.toString().toLowerCase() + "/training-voice/" + user.getId() + "/" + UUID.randomUUID() + ".wav";
+
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(new Date());
+            calendar.add(Calendar.MINUTE, 10);
+
+            String preSignedUrl = amazonS3.generatePresignedUrl(
+                    bucketName,
+                    objectKey,
+                    calendar.getTime(),
+                    HttpMethod.PUT
+            ).toString();
+
+            result.add(
+                    PreSignedUrlResponseDto.of(
+                            preSignedUrl,
+                            objectKey,
+                            calendar.getTime()
+                    )
+            );
+        }
+
+        return result;
+    }
+
+    public List<String> generatePreSignGetUrls(List<String> objectKeys, String bucketName) {
+        List<String> preSignedGeturls = new ArrayList<>();
+
+        for (String objectKey : objectKeys) {
+            Calendar calendar = Calendar.getInstance();
+            calendar.setTime(new Date());
+            calendar.add(Calendar.MINUTE, 10); // presigned URL 유효기간 10분
+
+            String preSignedUrl = amazonS3.generatePresignedUrl(
+                    bucketName,
+                    objectKey,
+                    calendar.getTime(),
+                    HttpMethod.GET
+            ).toString();
+
+            preSignedGeturls.add(preSignedUrl);
+        }
+
+        return preSignedGeturls;
+    }
+
+
 
 //    public List<String> listObjectKeys(String prefix, String bucketName) {
 //        ListObjectsV2Request req = new ListObjectsV2Request()

--- a/src/main/java/capstone/demo/domain/translatedText/TranslatedText.java
+++ b/src/main/java/capstone/demo/domain/translatedText/TranslatedText.java
@@ -28,5 +28,9 @@ public class TranslatedText extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    public synchronized void increaseCount() {
+        this.count = this.count + 1;
+    }
 }
 

--- a/src/main/java/capstone/demo/domain/translatedText/repository/TranslatedTextRepository.java
+++ b/src/main/java/capstone/demo/domain/translatedText/repository/TranslatedTextRepository.java
@@ -12,4 +12,6 @@ import java.util.Optional;
 public interface TranslatedTextRepository extends CrudRepository<TranslatedText, Long> {
 
     List<TranslatedText> findTop3ByUserOrderByCountDesc(User user);
+
+    Optional<TranslatedText> findByUserAndContent(User user, String content);
 }

--- a/src/main/java/capstone/demo/domain/translatedText/service/TranslatedTextService.java
+++ b/src/main/java/capstone/demo/domain/translatedText/service/TranslatedTextService.java
@@ -1,5 +1,6 @@
 package capstone.demo.domain.translatedText.service;
 
+import capstone.demo.domain.translatedText.TranslatedText;
 import capstone.demo.domain.translatedText.repository.TranslatedTextRepository;
 import capstone.demo.domain.translatedText.dto.TranslatedTextDTO;
 import capstone.demo.domain.user.entity.User;
@@ -23,5 +24,21 @@ public class TranslatedTextService {
                         .count(t.getCount())
                         .build())
                 .toList();
+    }
+
+    public TranslatedText saveTranslatedText(User user, String content) {
+        return translatedTextRepository.findByUserAndContent(user, content)
+                .map(existing -> {
+                    existing.increaseCount();
+                    return translatedTextRepository.save(existing);
+                })
+                .orElseGet(() -> {
+                    TranslatedText newText = TranslatedText.builder()
+                            .user(user)
+                            .content(content)
+                            .count(0)
+                            .build();
+                    return translatedTextRepository.save(newText);
+                });
     }
 }

--- a/src/main/java/capstone/demo/domain/user/entity/User.java
+++ b/src/main/java/capstone/demo/domain/user/entity/User.java
@@ -40,6 +40,8 @@ public class User extends BaseEntity {
     @Column(name = "login_type")
     private LoginType loginType;
 
+
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "user")
     private List<Bookmark> bookmarks = new ArrayList<>();
+
 }

--- a/src/main/java/capstone/demo/domain/user/service/UserService.java
+++ b/src/main/java/capstone/demo/domain/user/service/UserService.java
@@ -1,0 +1,13 @@
+package capstone.demo.domain.user.service;
+
+import capstone.demo.domain.user.entity.User;
+import capstone.demo.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+}

--- a/src/main/java/capstone/demo/domain/voice/VoiceRepository.java
+++ b/src/main/java/capstone/demo/domain/voice/VoiceRepository.java
@@ -1,9 +1,8 @@
 package capstone.demo.domain.voice;
 
-import org.springframework.data.jpa.repository.EntityGraph;
+import capstone.demo.domain.voice.entity.Voice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/capstone/demo/domain/voice/controller/VoiceController.java
+++ b/src/main/java/capstone/demo/domain/voice/controller/VoiceController.java
@@ -1,15 +1,14 @@
 package capstone.demo.domain.voice.controller;
 
 import capstone.demo.domain.emitter.EmitterService;
-import capstone.demo.domain.voice.dto.AiResultDTO;
 import capstone.demo.domain.voice.dto.AsyncResponseDTO;
 import capstone.demo.domain.voice.dto.FileUploadCompleteDTO;
 import capstone.demo.domain.voice.dto.VoiceDTO;
+import capstone.demo.domain.voice.entity.VoiceModel;
 import capstone.demo.domain.voice.service.VoiceService;
 import capstone.demo.global.apiPayload.ApiResponse;
 import capstone.demo.global.security.AuthDetails;
 import capstone.demo.global.security.jwt.TokenProvider;
-import capstone.demo.global.util.GlobalAuthUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,9 +17,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -44,16 +40,29 @@ public class VoiceController {
 
     @PostMapping("/voices/upload-complete")
     @Operation(summary = "음성 업로드 완료",
-            description = "S3 업로드 완료 후 objectKey와 uuid(emitterId)를 전달받아, DB 저장 및 AI 서버 분석 요청을 수행합니다.")
-    public ResponseEntity<ApiResponse<AsyncResponseDTO.AsyncTranslateDTO>> uploadComplete(
+            description = "S3 업로드 완료 후 objectKey, uuid(emitterId), 모델을 종류를 전달받아, DB 저장 및 AI 서버 분석 요청을 수행합니다.")
+    public ResponseEntity<ApiResponse<AsyncResponseDTO.AsyncTranslateDTO>> uploadCompleteAndAnalyze(
             @AuthenticationPrincipal AuthDetails authDetails,
-            @RequestBody FileUploadCompleteDTO.UploadCompleteRequest request) {
+            @RequestBody FileUploadCompleteDTO.UploadCompleteRequest request,
+            @RequestParam VoiceModel voiceModel) {
 
-        AsyncResponseDTO.AsyncTranslateDTO response = voiceService.handleUploadComplete(authDetails.user(), request);
+        AsyncResponseDTO.AsyncTranslateDTO response = voiceService.uploadCompleteAndAnalyze(authDetails.user(), request, voiceModel);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
+    @PostMapping("/voices/ai-learning")
+    @Operation(summary = "음성 학습 API",
+            description = "S3 업로드 완료 후 objectKeys, 모델을 종류를 전달받아, DB 저장 및 AI 모델 학습을 요청합니다.")
+    public ResponseEntity<ApiResponse<AsyncResponseDTO.AsyncTranslateDTO>> uploadCompleteAndLearning(
+            @AuthenticationPrincipal AuthDetails authDetails,
+            @RequestBody FileUploadCompleteDTO.UploadCompleteAndLearningRequest request,
+            @RequestParam VoiceModel voiceModel) {
+
+        AsyncResponseDTO.AsyncTranslateDTO response = voiceService.handleUploadCompleteAndLearning(authDetails.user(), request, voiceModel);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
 
     @GetMapping("/voices")
     @Operation(summary = "음성 기록 무한 스크롤 조회",

--- a/src/main/java/capstone/demo/domain/voice/controller/VoiceController.java
+++ b/src/main/java/capstone/demo/domain/voice/controller/VoiceController.java
@@ -49,36 +49,10 @@ public class VoiceController {
             @AuthenticationPrincipal AuthDetails authDetails,
             @RequestBody FileUploadCompleteDTO.UploadCompleteRequest request) {
 
-        Long userId = GlobalAuthUtil.extractUserId(authDetails);
-        System.out.println("userId = " + userId);
-
-        log.info("음성 업로드 완료 후 메소드 전");
-
-        AsyncResponseDTO.AsyncTranslateDTO response = voiceService.handleUploadComplete(userId, request);
+        AsyncResponseDTO.AsyncTranslateDTO response = voiceService.handleUploadComplete(authDetails.user(), request);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
-
-//    @PostMapping("/voices/ai-callback")
-//    @Operation(summary = "AI 분석 결과 콜백",
-//            description = "AI 서버에서 분석이 완료되면 이 API로 결과를 전송합니다.")
-//    public ResponseEntity<String> receiveAiResult(
-//            @AuthenticationPrincipal AuthDetails authDetails,
-//            @RequestBody AiResultDTO.AiResultRequestDTO result) {
-//
-//        Long userId = GlobalAuthUtil.extractUserId(authDetails);
-//
-//        Map<String, String> analysisResult = result.getResult();
-//
-//        AiResultDTO.AiResultResponseDTO data = AiResultDTO.AiResultResponseDTO.builder()
-//                        .requestId(result.getRequestId())
-//                        .text(analysisResult.get("text"))
-//                        .build();
-//
-//        emitterService.sendToEmitter(userId, result.getRequestId(), "complete", data);
-//
-//        return ResponseEntity.ok("SSE 전송 완료 for user " + userId);
-//    }
 
 
     @GetMapping("/voices")

--- a/src/main/java/capstone/demo/domain/voice/dto/AiResultDTO.java
+++ b/src/main/java/capstone/demo/domain/voice/dto/AiResultDTO.java
@@ -25,14 +25,14 @@ public class AiResultDTO {
     }
 
 
-//    @Builder
-//    @Getter
-//    @NoArgsConstructor
-//    @AllArgsConstructor
-//    public static class AiResultResponseDTO {
-//        private String requestId; // uuid
-//        private String text;
-//    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AiLearningResultResponseDTO {
+        private String requestId; // uuid
+        private Long adapterId;
+    }
 
 
 }

--- a/src/main/java/capstone/demo/domain/voice/dto/FileUploadCompleteDTO.java
+++ b/src/main/java/capstone/demo/domain/voice/dto/FileUploadCompleteDTO.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.util.Date;
+import java.util.List;
 
 public class FileUploadCompleteDTO {
 
@@ -16,6 +17,15 @@ public class FileUploadCompleteDTO {
     public static class UploadCompleteRequest {
         private String emitterId;
         private String objectKey;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UploadCompleteAndLearningRequest {
+        private String emitterId;
+        private List<String> objectKeys;
     }
 
     @Builder

--- a/src/main/java/capstone/demo/domain/voice/dto/VoiceDTO.java
+++ b/src/main/java/capstone/demo/domain/voice/dto/VoiceDTO.java
@@ -1,6 +1,6 @@
 package capstone.demo.domain.voice.dto;
 
-import capstone.demo.domain.voice.Voice;
+import capstone.demo.domain.voice.entity.Voice;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/capstone/demo/domain/voice/dto/VoiceDTO.java
+++ b/src/main/java/capstone/demo/domain/voice/dto/VoiceDTO.java
@@ -28,13 +28,15 @@ public class VoiceDTO {
         private Long voiceId;
         private String objectKey;
         private String translatedText;
+        private String translatedText_objectKey;
         private LocalDateTime createdAt;
 
-        public static VoiceDetailDTO from(Voice voice) {
+        public static VoiceDetailDTO from(Voice voice, String objectKey) {
             return VoiceDetailDTO.builder()
                     .voiceId(voice.getId())
                     .objectKey(voice.getObjectKey())
                     .translatedText(voice.getTranslatedText().getContent())
+                    .translatedText_objectKey(objectKey)
                     .createdAt(voice.getCreatedAt())
                     .build();
         }

--- a/src/main/java/capstone/demo/domain/voice/entity/Voice.java
+++ b/src/main/java/capstone/demo/domain/voice/entity/Voice.java
@@ -1,4 +1,4 @@
-package capstone.demo.domain.voice;
+package capstone.demo.domain.voice.entity;
 
 import capstone.demo.domain.translatedText.TranslatedText;
 import capstone.demo.domain.user.entity.User;

--- a/src/main/java/capstone/demo/domain/voice/entity/VoiceModel.java
+++ b/src/main/java/capstone/demo/domain/voice/entity/VoiceModel.java
@@ -1,0 +1,16 @@
+package capstone.demo.domain.voice.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum VoiceModel {
+    KOREAN("일반"),
+    HEARING("청각 장애"),
+    CP("뇌성 마비");
+
+    private final String description;
+
+    VoiceModel(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/capstone/demo/domain/voice/service/AiClientService.java
+++ b/src/main/java/capstone/demo/domain/voice/service/AiClientService.java
@@ -1,12 +1,14 @@
 package capstone.demo.domain.voice.service;
 
 import capstone.demo.domain.voice.dto.AiResultDTO;
+import capstone.demo.domain.voice.entity.VoiceModel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.List;
 import java.util.Map;
 
 
@@ -20,18 +22,16 @@ public class AiClientService {
     @Value("${ai.server.url}")
     private String ServerUrl;
 
-    @Value("${ai.server.korean-endpoint}")
-    private String koreanEndpoint;
+    public AiResultDTO.AiResultResponseDTO requestVoiceAnalysis(String emitterId, String presignedUrl, VoiceModel voiceModel, Long adapterNumberToUse) {
 
-    public AiResultDTO.AiResultResponseDTO requestVoiceAnalysis(String emitterId, String presignedUrl) {
-
-        String aiServerUrl = ServerUrl + koreanEndpoint;
+        String aiServerUrl = ServerUrl + voiceModel.toString().toLowerCase();
 
         Map<String, Object> body = Map.of(
                 "audioUrl", presignedUrl,
-                "emitterId", emitterId
+                "emitterId", emitterId,
+                "adapterNumber", adapterNumberToUse
         );
-        log.info("ai 요청 보낸 후");
+        log.info("ai 서버 요청 보낸 후");
 
         return webClient.post()
                 .uri(aiServerUrl)
@@ -42,5 +42,20 @@ public class AiClientService {
     }
 
 
+    public AiResultDTO.AiLearningResultResponseDTO requestVoiceLearning(String emitterId, List<String> presignedUrls, VoiceModel voiceModel) {
+        String aiServerUrl = ServerUrl + "adapter/train/" + voiceModel.toString().toLowerCase();
 
+        Map<String, Object> body = Map.of(
+                "audioUrls", presignedUrls,
+                "emitterId", emitterId
+        );
+        log.info("ai 학습 요청 보낸 후");
+
+        return webClient.post()
+                .uri(aiServerUrl)
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(AiResultDTO.AiLearningResultResponseDTO.class)
+                .block();    // 응답 DTO로 반환
+    }
 }

--- a/src/main/java/capstone/demo/domain/voice/service/VoiceService.java
+++ b/src/main/java/capstone/demo/domain/voice/service/VoiceService.java
@@ -1,5 +1,7 @@
 package capstone.demo.domain.voice.service;
 
+import capstone.demo.domain.adapter.Adapter;
+import capstone.demo.domain.adapter.AdapterService;
 import capstone.demo.domain.dictionary.Dictionary;
 import capstone.demo.domain.dictionary.service.DictionaryService;
 import capstone.demo.domain.emitter.EmitterService;
@@ -7,12 +9,14 @@ import capstone.demo.domain.fileload.S3FileService;
 import capstone.demo.domain.translatedText.TranslatedText;
 import capstone.demo.domain.translatedText.service.TranslatedTextService;
 import capstone.demo.domain.user.entity.User;
-import capstone.demo.domain.voice.Voice;
+import capstone.demo.domain.user.service.UserService;
+import capstone.demo.domain.voice.entity.Voice;
 import capstone.demo.domain.voice.VoiceRepository;
 import capstone.demo.domain.voice.dto.AiResultDTO;
 import capstone.demo.domain.voice.dto.AsyncResponseDTO;
 import capstone.demo.domain.voice.dto.FileUploadCompleteDTO;
 import capstone.demo.domain.voice.dto.VoiceDTO;
+import capstone.demo.domain.voice.entity.VoiceModel;
 import capstone.demo.global.apiPayload.code.status.ErrorStatus;
 import capstone.demo.global.apiPayload.exception.GeneralException;
 import capstone.demo.global.apiPayload.exception.handler.NotFoundHandler;
@@ -33,33 +37,39 @@ import java.util.stream.Collectors;
 @Slf4j
 public class VoiceService {
 
+    private final VoiceRepository voiceRepository;
+
     private final S3FileService s3FileService;
     private final AiClientService aiClientService;
     private final EmitterService emitterService;
-    private final ThreadPoolTaskExecutor voiceExecutor;
-    private final VoiceRepository voiceRepository;
     private final TranslatedTextService translatedTextService;
     private final DictionaryService dictionaryService;
+    private final AdapterService adapterService;
+
+    private final ThreadPoolTaskExecutor voiceExecutor;
 
     @Value("${amazon.aws.bucket}")
     private String bucketName;
 
-    public AsyncResponseDTO.AsyncTranslateDTO handleUploadComplete(
-            User user, FileUploadCompleteDTO.UploadCompleteRequest request) {
-            Long userId = user.getId();
+    public AsyncResponseDTO.AsyncTranslateDTO uploadCompleteAndAnalyze(
+            User user, FileUploadCompleteDTO.UploadCompleteRequest request, VoiceModel voiceModel) {
             log.info("ai 요청 준비");
+
+            Adapter adapter = adapterService.findByUser(user);
+
+            Long adapterNumberToUse = (adapter.getVoiceModel() == voiceModel ? adapter.getAdapterNumber() : null);
 
             CompletableFuture.supplyAsync(() -> {
                         String presignedUrl = s3FileService.generatePreSignGetUrl(request.getObjectKey(), bucketName);
-                        return aiClientService.requestVoiceAnalysis(request.getEmitterId(), presignedUrl);
+                        return aiClientService.requestVoiceAnalysis(request.getEmitterId(), presignedUrl, voiceModel, adapterNumberToUse);
                     }, voiceExecutor)
                     .thenAccept(result -> {
-                        emitterService.sendToEmitter(userId, request.getEmitterId(),"complete", result);
+                        emitterService.sendToEmitter(user.getId(), request.getEmitterId(),"complete", result);
                         saveVoiceAnalysis(user, request.getObjectKey(), result);
                         log.info("sse 결과 출력 성공");
                     })
                     .exceptionally(ex -> {
-                        emitterService.sendToEmitter(userId, request.getEmitterId(),"error", ex.getMessage());
+                        emitterService.sendToEmitter(user.getId(), request.getEmitterId(),"error", ex.getMessage());
                         log.info("sse 결과 출력 error");
                         return null;
                     });
@@ -97,7 +107,7 @@ public class VoiceService {
                         voices.stream()
                                 .map(voice -> VoiceDTO.VoiceDetailDTO.from(
                                         voice,
-                                        dictMap.get(voice.getTranslatedText().getContent()) // 매칭된 objectKey
+                                        dictMap.get(voice.getTranslatedText().getContent())
                                 ))
                                 .toList()
                 )
@@ -135,4 +145,25 @@ public class VoiceService {
         voiceRepository.save(voice);
     }
 
+    public AsyncResponseDTO.AsyncTranslateDTO handleUploadCompleteAndLearning(User user, FileUploadCompleteDTO.UploadCompleteAndLearningRequest request, VoiceModel voiceModel) {
+
+        CompletableFuture.supplyAsync(() -> {
+                    List<String> presignedUrls = s3FileService.generatePreSignGetUrls(request.getObjectKeys(), bucketName);
+                    return aiClientService.requestVoiceLearning(request.getEmitterId(), presignedUrls, voiceModel);
+                }, voiceExecutor)
+                .thenAccept(result -> {
+                    emitterService.sendToEmitter(user.getId(), request.getEmitterId(),"complete", result);
+                    adapterService.saveUsersAdapterId(user, result.getAdapterId(), voiceModel);
+                    log.info("sse 결과 출력 성공");
+                })
+                .exceptionally(ex -> {
+                    emitterService.sendToEmitter(user.getId(), request.getEmitterId(),"error", ex.getMessage());
+                    log.info("sse 결과 출력 error");
+                    return null;
+                });
+
+        return AsyncResponseDTO.AsyncTranslateDTO.builder()
+                .message("모델 학습이 진행중입니다. 끝나면 알려드릴게요!")
+                .build();
+    }
 }

--- a/src/main/java/capstone/demo/domain/voice/service/VoiceService.java
+++ b/src/main/java/capstone/demo/domain/voice/service/VoiceService.java
@@ -1,5 +1,7 @@
 package capstone.demo.domain.voice.service;
 
+import capstone.demo.domain.dictionary.Dictionary;
+import capstone.demo.domain.dictionary.service.DictionaryService;
 import capstone.demo.domain.emitter.EmitterService;
 import capstone.demo.domain.fileload.S3FileService;
 import capstone.demo.domain.translatedText.TranslatedText;
@@ -24,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +39,7 @@ public class VoiceService {
     private final ThreadPoolTaskExecutor voiceExecutor;
     private final VoiceRepository voiceRepository;
     private final TranslatedTextService translatedTextService;
+    private final DictionaryService dictionaryService;
 
     @Value("${amazon.aws.bucket}")
     private String bucketName;
@@ -75,11 +79,26 @@ public class VoiceService {
 
         int totalCount = voiceRepository.countByUserId(userId);
 
+        List<String> contents = voices.stream()
+                .map(v -> v.getTranslatedText().getContent())
+                .toList();
+
+        List<Dictionary> dictionaries = dictionaryService.findAllByGestureNameIn(contents);
+
+        Map<String, String> dictMap = dictionaries.stream()
+                .collect(Collectors.toMap(
+                        Dictionary::getGestureName,
+                        Dictionary::getObjectKey
+                ));
+
         return VoiceDTO.VoiceListResponseDTO.builder()
                 .totalCount(totalCount)
                 .voices(
                         voices.stream()
-                                .map(VoiceDTO.VoiceDetailDTO::from)
+                                .map(voice -> VoiceDTO.VoiceDetailDTO.from(
+                                        voice,
+                                        dictMap.get(voice.getTranslatedText().getContent()) // 매칭된 objectKey
+                                ))
                                 .toList()
                 )
                 .build();

--- a/src/main/java/capstone/demo/domain/voice/service/VoiceService.java
+++ b/src/main/java/capstone/demo/domain/voice/service/VoiceService.java
@@ -2,9 +2,12 @@ package capstone.demo.domain.voice.service;
 
 import capstone.demo.domain.emitter.EmitterService;
 import capstone.demo.domain.fileload.S3FileService;
+import capstone.demo.domain.translatedText.TranslatedText;
+import capstone.demo.domain.translatedText.service.TranslatedTextService;
 import capstone.demo.domain.user.entity.User;
 import capstone.demo.domain.voice.Voice;
 import capstone.demo.domain.voice.VoiceRepository;
+import capstone.demo.domain.voice.dto.AiResultDTO;
 import capstone.demo.domain.voice.dto.AsyncResponseDTO;
 import capstone.demo.domain.voice.dto.FileUploadCompleteDTO;
 import capstone.demo.domain.voice.dto.VoiceDTO;
@@ -19,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 @Service
@@ -31,13 +35,14 @@ public class VoiceService {
     private final EmitterService emitterService;
     private final ThreadPoolTaskExecutor voiceExecutor;
     private final VoiceRepository voiceRepository;
+    private final TranslatedTextService translatedTextService;
 
     @Value("${amazon.aws.bucket}")
     private String bucketName;
 
     public AsyncResponseDTO.AsyncTranslateDTO handleUploadComplete(
-            Long userId, FileUploadCompleteDTO.UploadCompleteRequest request) {
-
+            User user, FileUploadCompleteDTO.UploadCompleteRequest request) {
+            Long userId = user.getId();
             log.info("ai 요청 준비");
 
             CompletableFuture.supplyAsync(() -> {
@@ -46,8 +51,8 @@ public class VoiceService {
                     }, voiceExecutor)
                     .thenAccept(result -> {
                         emitterService.sendToEmitter(userId, request.getEmitterId(),"complete", result);
+                        saveVoiceAnalysis(user, request.getObjectKey(), result);
                         log.info("sse 결과 출력 성공");
-
                     })
                     .exceptionally(ex -> {
                         emitterService.sendToEmitter(userId, request.getEmitterId(),"error", ex.getMessage());
@@ -90,9 +95,25 @@ public class VoiceService {
             throw new GeneralException(ErrorStatus._UNAUTHORIZED);
         }
 
-        // S3 파일 삭제
-//         s3FileService.deleteObjectFromS3(voice.getObjectKey(), bucketName);
+         s3FileService.deleteObjectFromS3(voice.getObjectKey(), bucketName);
 
         voiceRepository.delete(voice);
     }
+
+
+    public void saveVoiceAnalysis(User user, String objectKey, AiResultDTO.AiResultResponseDTO dto) {
+
+        Map<String, String> responseText = dto.getResult();
+
+        TranslatedText translatedText = translatedTextService.saveTranslatedText(user, responseText.get("text"));
+
+        Voice voice = Voice.builder()
+                .user(user)
+                .objectKey(objectKey)
+                .translatedText(translatedText)
+                .build();
+
+        voiceRepository.save(voice);
+    }
+
 }


### PR DESCRIPTION
@권용빈 오늘 구현한거 전달드릴게요 ! 프론트에서 어떻게 해야하는지 적어놓은거 참고하시면 좋을 것 같고 모르는거는 바로 질문주세요~ 
그리고 내일 연결한 담에 한번에 push 하겠습니다.

1. 백과사전 데이터 insert완료 , 수화 데이터 읽을때는 object key로 presignedGet url 발급해서 가져온다음에 재생

2. 북마크 등록/해제 -> put method 하나로 합쳤습니다.

3. 말하기 버튼 및 듣기 버튼 2개로 나누어, 보정기능이 들어간 모델과 일반 음성 모델로 나누어서 쌍방향 소통
 -> 동일 url 사용, requestParameter(KOREAN, HEARING, CP) 프론트에서 사용자가 설정한거에 따라 매핑해서 요청보내기

4. 사용 기록에서 특정 수화를 영상으로 보여주기 -> 매핑되는만 뜨게 구현 (데이터 읽을때는 object key로 presignedGet url 발급해서 가져온다음에 재생)

5. 설정창에서 ai 모델선택 및 학습 기능 추가로 개인화 모델 만들수있게 하기
-> presigned put url 20개 발급 API 호출 -> 프론트에서 데이터 올리기
-> sse 연결
-> 음성 학습 API호출
-> sse응답 받으면 프론트에서 알림주기 (알림은 프론트에서 구현해야할 것 같아요)